### PR TITLE
Fix redirect to correct document URL on file load

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,14 @@
         "npm-run-all": "^4.1.5",
         "parcel": "^2.3.2",
         "process": "^0.11.10"
+      },
+      "optionalDependencies": {
+        "@tauri-apps/cli-darwin-x64": "1.0.0-rc.9",
+        "@tauri-apps/cli-linux-arm64-gnu": "1.0.0-rc.9",
+        "@tauri-apps/cli-linux-arm64-musl": "1.0.0-rc.9",
+        "@tauri-apps/cli-linux-x64-gnu": "1.0.0-rc.9",
+        "@tauri-apps/cli-linux-x64-musl": "1.0.0-rc.9",
+        "@tauri-apps/cli-win32-x64-msvc": "1.0.0-rc.9"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3450,6 +3458,7 @@
       "version": "1.0.0-rc.9",
       "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-1.0.0-rc.9.tgz",
       "integrity": "sha512-j+HZ65wdfFrMwisYeQpdZnldONevBPHjAo9v9Impf0irUU2UR5nwyvyArHTaWCvNeqEs+YV4XXHsfm2xVpnaug==",
+      "dev": true,
       "bin": {
         "tauri": "tauri.js"
       },
@@ -3479,9 +3488,100 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-darwin-x64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-ku8QpMNrfqyCk2adLdVB+zzaCb7T0/RgVvaqEZqK54WW4blUxkeKHbKqZ/SKRdxTkghHbgJIoBtlk1A5GUbAwg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-arm64-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-Rr4S902dYjRnDCu141f5Cz3JxwKxX/ax7LiMhSifQu5o2wSiezmZ20VRHBwW1UuZxvGV+hxTuZVnfD6NKQdWdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-arm64-musl": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.0.0-rc.9.tgz",
+      "integrity": "sha512-MxqjspY2aS/nxtvBMT8TExZfDWDEsUvQRHHY/2KoBYpqpzucW6WXRGmeOvS1GeA3vnub2/Kq5i32jGRDT1tvrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-x64-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-LD7KnJuH1mYFwQfcALPttBnaSG6pgO87Z6nY3xXJjo+A4ttPHcmIBaNdXCTjAmib/umD0nD8k95Hw9iJFYTuiA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-x64-musl": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-1.0.0-rc.9.tgz",
+      "integrity": "sha512-ifocAxBYhk7qrO5x1mizxx/yABvkmyia0kw9eXUn7d5a30HoBcl/A9t+w+7c4B/n/D+gxEMSr6CPaIZv7KnTog==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-win32-x64-msvc": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-1.0.0-rc.9.tgz",
+      "integrity": "sha512-hJjnpl864OhpIp2lTMTW4ad2Aia5/Tbf7k8GJILzUY/XkBhZjNIgZORa8bDcnZRCTU+RDgMFc+AoKtDIircjnA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -9778,6 +9878,7 @@
       "version": "1.0.0-rc.9",
       "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-1.0.0-rc.9.tgz",
       "integrity": "sha512-j+HZ65wdfFrMwisYeQpdZnldONevBPHjAo9v9Impf0irUU2UR5nwyvyArHTaWCvNeqEs+YV4XXHsfm2xVpnaug==",
+      "dev": true,
       "requires": {
         "@tauri-apps/cli-darwin-arm64": "1.0.0-rc.9",
         "@tauri-apps/cli-darwin-x64": "1.0.0-rc.9",
@@ -9794,6 +9895,43 @@
       "version": "1.0.0-rc.9",
       "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-1.0.0-rc.9.tgz",
       "integrity": "sha512-cpcSRyVOh3n5GsCdKtVQpLJ36yx7h+KY868l7KhPnM5EL1cQbFwYzD/VHlzFvfrpS19YvPBB/AHln4rll5iWvw==",
+      "dev": true,
+      "optional": true
+    },
+    "@tauri-apps/cli-darwin-x64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-ku8QpMNrfqyCk2adLdVB+zzaCb7T0/RgVvaqEZqK54WW4blUxkeKHbKqZ/SKRdxTkghHbgJIoBtlk1A5GUbAwg==",
+      "optional": true
+    },
+    "@tauri-apps/cli-linux-arm64-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-Rr4S902dYjRnDCu141f5Cz3JxwKxX/ax7LiMhSifQu5o2wSiezmZ20VRHBwW1UuZxvGV+hxTuZVnfD6NKQdWdA==",
+      "optional": true
+    },
+    "@tauri-apps/cli-linux-arm64-musl": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.0.0-rc.9.tgz",
+      "integrity": "sha512-MxqjspY2aS/nxtvBMT8TExZfDWDEsUvQRHHY/2KoBYpqpzucW6WXRGmeOvS1GeA3vnub2/Kq5i32jGRDT1tvrA==",
+      "optional": true
+    },
+    "@tauri-apps/cli-linux-x64-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-LD7KnJuH1mYFwQfcALPttBnaSG6pgO87Z6nY3xXJjo+A4ttPHcmIBaNdXCTjAmib/umD0nD8k95Hw9iJFYTuiA==",
+      "optional": true
+    },
+    "@tauri-apps/cli-linux-x64-musl": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-1.0.0-rc.9.tgz",
+      "integrity": "sha512-ifocAxBYhk7qrO5x1mizxx/yABvkmyia0kw9eXUn7d5a30HoBcl/A9t+w+7c4B/n/D+gxEMSr6CPaIZv7KnTog==",
+      "optional": true
+    },
+    "@tauri-apps/cli-win32-x64-msvc": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-1.0.0-rc.9.tgz",
+      "integrity": "sha512-hJjnpl864OhpIp2lTMTW4ad2Aia5/Tbf7k8GJILzUY/XkBhZjNIgZORa8bDcnZRCTU+RDgMFc+AoKtDIircjnA==",
       "optional": true
     },
     "@tldraw/core": {

--- a/src/adapters/yjs/index.ts
+++ b/src/adapters/yjs/index.ts
@@ -123,9 +123,9 @@ export const useYjsSession = (app: TldrawApp, boardId: string): FSAdapter => {
    * Load a binary representation of a document into the page and
    * reconnect the network provider.
    */
-  const loadDocument = (binary: Uint8Array): string => {
+  const loadDocument = (serialisedDocument: Uint8Array): string => {
     setLoading(true);
-    store.reset(binary);
+    store.reset(serialisedDocument);
     if (networkProvider) networkProvider.disconnect();
     replacePageWithDocState();
     setLoading(false);

--- a/src/adapters/yjs/index.ts
+++ b/src/adapters/yjs/index.ts
@@ -109,7 +109,7 @@ export const useYjsSession = (app: TldrawApp, boardId: string): FSAdapter => {
    * Create a new board and return its id.
    */
   const createDocument = (): string => {
-    store.reset();
+    store.reset(null);
     const newBoardId = uuid();
     // Prevent undoing initial set of the board id
     store.undoManager.stopCapturing();
@@ -122,14 +122,10 @@ export const useYjsSession = (app: TldrawApp, boardId: string): FSAdapter => {
   /**
    * Load a binary representation of a document into the page and
    * reconnect the network provider.
-   *
-   * @param binary
-   * @returns
    */
   const loadDocument = (binary: Uint8Array): string => {
     setLoading(true);
-    store.reset();
-    Y.applyUpdate(store.doc, binary);
+    store.reset(binary);
     if (networkProvider) networkProvider.disconnect();
     replacePageWithDocState();
     setLoading(false);

--- a/src/adapters/yjs/store.ts
+++ b/src/adapters/yjs/store.ts
@@ -18,11 +18,12 @@ export class Doc {
   undoManager: Y.UndoManager;
 
   constructor() {
-    this.reset();
+    this.reset(null);
   }
 
-  reset() {
+  reset(initialUpdate: any) {
     this.doc = new Y.Doc();
+    if (initialUpdate) Y.applyUpdate(this.doc, initialUpdate);
     this.yShapes = this.doc.getMap("shapes");
     this.yBindings = this.doc.getMap("bindings");
     this.board = this.doc.getMap("board");

--- a/src/adapters/yjs/store.ts
+++ b/src/adapters/yjs/store.ts
@@ -21,7 +21,7 @@ export class Doc {
     this.reset(null);
   }
 
-  reset(initialUpdate: any) {
+  reset(initialUpdate: Uint8Array) {
     this.doc = new Y.Doc();
     if (initialUpdate) Y.applyUpdate(this.doc, initialUpdate);
     this.yShapes = this.doc.getMap("shapes");

--- a/src/pages/Board.tsx
+++ b/src/pages/Board.tsx
@@ -23,7 +23,7 @@ const Board = () => {
     [boardId]
   );
 
-  const session = useYjsSession(app, boardId, handleMount);
+  const session = useYjsSession(app, boardId);
 
   const handleNewProject = () => {
     const newBoardId = session.createDocument();


### PR DESCRIPTION
This doesn't work with old document files that don't contain board metadata.

Maybe we should have a version identifier in the document itself?

Closes #31 