### PR TITLE
fix: Throttle presence

### DIFF
--- a/src/adapters/yjs/presence.ts
+++ b/src/adapters/yjs/presence.ts
@@ -2,7 +2,10 @@ import { TDUser, TldrawApp } from "@tldraw/tldraw";
 import { Room } from "@y-presence/client";
 import { WebsocketProvider } from "y-websocket";
 
+import { throttle } from "lodash";
 import { TldrawPresence } from "../../types";
+
+const THROTLE_MS = 150
 
 export default class Presence {
   room: Room;
@@ -15,13 +18,13 @@ export default class Presence {
   connect(app: TldrawApp) {
     this._handleDisconnect = this.room.subscribe<TldrawPresence>(
       "others",
-      (users: any) => {
+      throttle((users: any) => {
         if (!app.room) return;
-
         // Extract all user ids that have presence information
         const present_ids = users
           .filter((user) => user.presence)
           .map((user) => user.presence!.tdUser.id);
+
 
         const currentUser = app.room?.userId;
 
@@ -43,7 +46,7 @@ export default class Presence {
             .map((other) => other.presence!.tdUser)
             .filter(Boolean)
         );
-      }
+      }, THROTLE_MS)
     );
   }
 


### PR DESCRIPTION
This fixes a bug where presence information (e.g., cursor position) would get updated rapidly -- faster than the human eye or HTTP/Websocket requests could handle them. They would pile up on each other over time and cause visible lag when the cursor moved a lot. Now, you can move the cursor rapidly and it won't replay all of the changes in between.