### PR TITLE
Refuse loading a document without a board id

### DIFF
--- a/src/adapters/yjs/index.ts
+++ b/src/adapters/yjs/index.ts
@@ -129,7 +129,12 @@ export const useYjsSession = (app: TldrawApp, boardId: string): FSAdapter => {
     if (networkProvider) networkProvider.disconnect();
     replacePageWithDocState();
     setLoading(false);
-    return store.board.get("id");
+    const boardId = store.board.get("id");
+    if (boardId == null) {
+      alert("Outdated document doesn't contain a board id");
+      return createDocument();
+    }
+    return boardId;
   };
 
   /**

--- a/src/adapters/yjs/store.ts
+++ b/src/adapters/yjs/store.ts
@@ -21,7 +21,12 @@ export class Doc {
     this.reset(null);
   }
 
-  reset(initialUpdate: Uint8Array) {
+  /**
+   * Reset the document store with an optional initial update to apply.
+   *
+   * @param initialUpdate serialised yjs update
+   */
+  reset(initialUpdate: Uint8Array | null) {
     this.doc = new Y.Doc();
     if (initialUpdate) Y.applyUpdate(this.doc, initialUpdate);
     this.yShapes = this.doc.getMap("shapes");


### PR DESCRIPTION
Loading a document without a board id would load the board `undefined` (hello javascript). This displays an `alert` instead for now.