### PR TITLE
Add onboarding dialogue when joining a board on the web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added self-hosted Urbanist web font [#59](https://github.com/interalia-studio/fullscreen/pull/59)
 - Added more tools to the new toolbar [#61](https://github.com/interalia-studio/fullscreen/pull/61)
 - Added Typescript config [#64](https://github.com/interalia-studio/fullscreen/pull/64)
+- Onboarding dialogue when joining a board on the web [#66](https://github.com/interalia-studio/fullscreen/pull/66)
 
 ### Changed
 

--- a/src/adapters/yjs/identity.ts
+++ b/src/adapters/yjs/identity.ts
@@ -1,0 +1,42 @@
+import { v4 as uuid } from "uuid";
+
+import { UserId } from "~/types";
+
+// Key to use for storing user id in localstorage.
+const LOCALSTORAGE_USER_ID_KEY = "fs-user-id";
+
+/**
+ * Returns the current user's Fullscreen user id.
+ *
+ * The id is stored in localstorage and a new one is created if no id was found.
+ */
+export const getUserId = (): UserId => {
+  let storedUserId: UserId;
+  try {
+    storedUserId = localStorage.getItem(LOCALSTORAGE_USER_ID_KEY);
+  } catch {
+    console.error("Could not get user id from localStorage");
+  }
+
+  let newUserId: UserId;
+  if (storedUserId == null) {
+    newUserId = uuid();
+    try {
+      localStorage.setItem(LOCALSTORAGE_USER_ID_KEY, newUserId);
+    } catch {
+      console.error("Could not store user id in localStorage");
+    }
+  }
+  return storedUserId || newUserId;
+};
+
+/**
+ * Update the Fullscreen user id in localStorage.
+ */
+export const storeUserId = (userId: UserId) => {
+  try {
+    localStorage.setItem(LOCALSTORAGE_USER_ID_KEY, userId);
+  } catch {
+    console.error("Could not store user id");
+  }
+};

--- a/src/adapters/yjs/index.ts
+++ b/src/adapters/yjs/index.ts
@@ -7,7 +7,7 @@ import * as Y from "yjs";
 import { FileProvider } from "./fileProvider";
 import Presence from "./presence";
 import store from "./store";
-import { BoardId, BoardMeta, FSAdapter, UserId } from "~/types";
+import { BoardId, BoardMeta, FSAdapter, FSUser, UserId } from "~/types";
 import { getUserId } from "./identity";
 
 /**
@@ -24,9 +24,10 @@ export const useYjsSession = (
   // This is false until the page state has been loaded from yjs
   const [isLoading, setLoading] = useState(true);
 
-  // Fullscreen-scoped user id.
-  const [userId, _] = useState<UserId>(getUserId());
+  // Fullscreen-scoped user.
+  const [fsUser, _] = useState<FSUser>({ id: getUserId() });
 
+  // Board metadata synced to y.js
   const [boardMeta, setBoardMeta] = useState<BoardMeta>(null);
 
   // @TODO: Connect file provider to file handle after saving from a browser that
@@ -145,7 +146,7 @@ export const useYjsSession = (
     store.undoManager.stopCapturing();
     store.doc.transact(() => {
       store.board.set("id", newBoardId);
-      store.board.set("createdBy", userId);
+      store.board.set("createdBy", fsUser.id);
       store.board.set("createdOn", new Date().toUTCString());
     });
 
@@ -188,7 +189,7 @@ export const useYjsSession = (
     store.undoManager.stopCapturing();
     const newBoardId = uuid();
     store.board.set("id", newBoardId);
-    store.board.set("createdBy", userId);
+    store.board.set("createdBy", fsUser.id);
     store.board.set("createdOn", new Date().toUTCString());
     return newBoardId;
   };
@@ -209,9 +210,7 @@ export const useYjsSession = (
       createdBy: boardMeta?.createdBy,
       createdOn: boardMeta?.createdOn,
     },
-    user: {
-      id: userId,
-    },
+    user: fsUser,
     eventHandlers: {
       onChangePage: handleChangePage,
 

--- a/src/adapters/yjs/index.ts
+++ b/src/adapters/yjs/index.ts
@@ -7,7 +7,7 @@ import * as Y from "yjs";
 import { FileProvider } from "./fileProvider";
 import Presence from "./presence";
 import store from "./store";
-import { FSAdapter } from "~/types";
+import { BoardId, FSAdapter } from "~/types";
 
 /**
  * A `YjsSession` uses a Websocket connection to a relay server to sync document
@@ -15,7 +15,11 @@ import { FSAdapter } from "~/types";
  *
  * It can serialise and deserialise to a binary format.
  */
-export const useYjsSession = (app: TldrawApp, boardId: string): FSAdapter => {
+export const useYjsSession = (
+  app: TldrawApp,
+  passive: boolean,
+  boardId: BoardId
+): FSAdapter => {
   // This is false until the page state has been loaded from yjs
   const [isLoading, setLoading] = useState(true);
 
@@ -134,10 +138,23 @@ export const useYjsSession = (app: TldrawApp, boardId: string): FSAdapter => {
     replacePageWithDocState();
     setLoading(false);
     const boardId = store.board.get("id");
+    // TODO: Remove this once yjs.fullscreen.space doesn't contain documents without `boardId`.
     if (boardId == null) {
       alert("Outdated document doesn't contain a board id");
       return createDocument();
     }
+    return boardId;
+  };
+
+  /**
+   * Create a copy of a board that can be edited independently.
+   *
+   * @param boardId the original boardId
+   * @returns the newly created boardId
+   */
+  const createDuplicate = async (boardId: BoardId): Promise<BoardId> => {
+    // TODO
+    console.log("createDuplicate not yet implemented");
     return boardId;
   };
 
@@ -150,6 +167,7 @@ export const useYjsSession = (app: TldrawApp, boardId: string): FSAdapter => {
     isLoading,
     createDocument,
     loadDocument,
+    createDuplicate,
     serialiseDocument,
     eventHandlers: {
       onChangePage: handleChangePage,
@@ -164,7 +182,7 @@ export const useYjsSession = (app: TldrawApp, boardId: string): FSAdapter => {
 
       onChangePresence: useCallback(
         (app: TldrawApp, user: TDUser) =>
-          app && room && room.update(app.room.userId, user),
+          app && !passive && room && room.update(app.room.userId, user),
         [room]
       ),
     },

--- a/src/adapters/yjs/index.ts
+++ b/src/adapters/yjs/index.ts
@@ -62,6 +62,17 @@ export const useYjsSession = (
   };
 
   /**
+   * Update board metadata state from y.js
+   */
+  const updateBoardMeta = () => {
+    setBoardMeta({
+      id: store.board.get("id"),
+      createdBy: store.board.get("createdBy"),
+      createdOn: new Date(store.board.get("createdOn")),
+    });
+  };
+
+  /**
    * Handle changes made through the TLDraw widget.
    */
   const handleChangePage = useCallback(
@@ -100,14 +111,9 @@ export const useYjsSession = (
     room.connect(app);
 
     async function setup() {
+      store.board.observe(updateBoardMeta);
       store.yShapes.observeDeep(replacePageWithDocState);
-      store.board.observe(() => {
-        setBoardMeta({
-          id: store.board.get("id"),
-          createdBy: store.board.get("createdBy"),
-          createdOn: new Date(store.board.get("createdOn")),
-        });
-      });
+      updateBoardMeta;
       replacePageWithDocState();
       setLoading(false);
     }

--- a/src/components/Canvas/Canvas.tsx
+++ b/src/components/Canvas/Canvas.tsx
@@ -17,7 +17,7 @@ export const Canvas = ({ boardId }: { boardId: string }) => {
 
   // Set to false to "watch" the board without indicating presence or
   // making changes.
-  const [shouldJoin, setShouldJoin] = useState<boolean>(false);
+  const [shouldJoin, setShouldJoin] = useState<boolean>(isNativeApp());
 
   // True while a board is being duplicated.
   const [isCopyingBoard, setIsCopyingBoard] = useState<boolean>(false);
@@ -93,7 +93,7 @@ export const Canvas = ({ boardId }: { boardId: string }) => {
         <AppContext.Provider value={tldrawApp}>
           <Toolbar />
 
-          {/* Show _Join Board_ dialogue until user has decided to join or navigated away. */}
+          {/* Show _Join Board_ dialogue for web users until user has decided to join or navigated away. */}
           {shouldJoin != true && (
             <JoinBoard
               onJoin={() => setShouldJoin(true)}

--- a/src/components/Canvas/Canvas.tsx
+++ b/src/components/Canvas/Canvas.tsx
@@ -30,6 +30,11 @@ export const Canvas = ({ boardId }: { boardId: string }) => {
 
   const session = useYjsSession(tldrawApp, !shouldJoin, boardId);
 
+  useEffect(() => {
+    if (session?.board == null || session?.user == null) return;
+    setShouldJoin(session.board.createdBy === session.user.id);
+  }, [session?.board]);
+
   const handleNewProject = () => {
     const newBoardId = session.createDocument();
     navigate(`/board/${newBoardId}`);

--- a/src/components/Canvas/Canvas.tsx
+++ b/src/components/Canvas/Canvas.tsx
@@ -19,9 +19,6 @@ export const Canvas = ({ boardId }: { boardId: string }) => {
   // making changes.
   const [shouldJoin, setShouldJoin] = useState<boolean>(isNativeApp());
 
-  // True while a board is being duplicated.
-  const [isCopyingBoard, setIsCopyingBoard] = useState<boolean>(false);
-
   const handleMount = useCallback(
     (tldraw: TldrawApp) => {
       tldraw.loadRoom(boardId);
@@ -67,9 +64,7 @@ export const Canvas = ({ boardId }: { boardId: string }) => {
   }, []);
 
   const openDuplicate = async () => {
-    setIsCopyingBoard(true);
-    const newBoardId = await session.createDuplicate(boardId);
-    setIsCopyingBoard(false);
+    const newBoardId = session.createDuplicate(boardId);
     navigate(`/board/${newBoardId}`);
   };
 
@@ -98,7 +93,6 @@ export const Canvas = ({ boardId }: { boardId: string }) => {
             <JoinBoard
               onJoin={() => setShouldJoin(true)}
               onCopyBoard={openDuplicate}
-              isCopyingBoard={isCopyingBoard}
             />
           )}
         </AppContext.Provider>

--- a/src/components/Canvas/context.ts
+++ b/src/components/Canvas/context.ts
@@ -1,4 +1,7 @@
 import { TldrawApp } from "@tldraw/tldraw";
 import React from "react";
 
+/**
+ * Provides access to the TLDraw instance.
+ */
 export const AppContext = React.createContext<TldrawApp>({} as any);

--- a/src/components/JoinBoard/JoinBoard.tsx
+++ b/src/components/JoinBoard/JoinBoard.tsx
@@ -3,14 +3,9 @@ import { styled } from "~/styles";
 type JoinBoardProps = {
   onJoin: () => any;
   onCopyBoard: () => any;
-  isCopyingBoard: boolean;
 };
 
-export const JoinBoard = ({
-  onJoin,
-  onCopyBoard,
-  isCopyingBoard,
-}: JoinBoardProps) => {
+export const JoinBoard = ({ onJoin, onCopyBoard }: JoinBoardProps) => {
   return (
     <ModalWrapper>
       <Dialogue>
@@ -23,12 +18,10 @@ export const JoinBoard = ({
           with anyone who has the link?
         </DialogueBody>
         <DialogueActions>
-          <Button primary onClick={onJoin} disabled={isCopyingBoard}>
+          <Button primary onClick={onJoin}>
             Join this board
           </Button>
-          <Button onClick={onCopyBoard} disabled={true}>
-            Make a copy
-          </Button>
+          <Button onClick={onCopyBoard}>Make a copy</Button>
         </DialogueActions>
       </Dialogue>
     </ModalWrapper>

--- a/src/components/JoinBoard/JoinBoard.tsx
+++ b/src/components/JoinBoard/JoinBoard.tsx
@@ -1,3 +1,4 @@
+import { useYjsSession } from "~/adapters/yjs";
 import { styled } from "~/styles";
 
 type JoinBoardProps = {
@@ -68,19 +69,23 @@ const Button = styled("button", {
   display: "inline-block",
   padding: "5px 10px",
   backgroundColor: "white",
-  borderRadius: 3,
+  borderRadius: "$2",
+  borderWidth: "2px",
   cursor: "pointer",
   "& + &": {
     marginLeft: 10,
   },
   "&:hover": {
-    backdropFilter: "brightness(85%)",
+    backgroundColor: "$hover",
   },
   variants: {
     primary: {
       true: {
         backgroundColor: "$blue",
         color: "white",
+        "&:hover": {
+          backgroundColor: "$blueHover",
+        },
       },
     },
   },

--- a/src/components/JoinBoard/JoinBoard.tsx
+++ b/src/components/JoinBoard/JoinBoard.tsx
@@ -1,0 +1,94 @@
+import { styled } from "~/styles";
+
+type JoinBoardProps = {
+  onJoin: () => any;
+  onCopyBoard: () => any;
+  isCopyingBoard: boolean;
+};
+
+export const JoinBoard = ({
+  onJoin,
+  onCopyBoard,
+  isCopyingBoard,
+}: JoinBoardProps) => {
+  return (
+    <ModalWrapper>
+      <Dialogue>
+        <DialogueHeader>
+          <h1>Fullscreen Sprint 3</h1>
+          <h2>Created by Rae on April 24, 2022</h2>
+        </DialogueHeader>
+        <DialogueBody>
+          Do you want to join this collaborative board and sync your changes
+          with anyone who has the link?
+        </DialogueBody>
+        <DialogueActions>
+          <Button primary onClick={onJoin} disabled={isCopyingBoard}>
+            Join this board
+          </Button>
+          <Button onClick={onCopyBoard} disabled={true}>
+            Make a copy
+          </Button>
+        </DialogueActions>
+      </Dialogue>
+    </ModalWrapper>
+  );
+};
+
+const ModalWrapper = styled("div", {
+  position: "absolute",
+  top: 0,
+  left: 0,
+  width: "100vw",
+  height: "100vh",
+  backgroundColor: "rgba(255, 255, 255, 0.7)",
+  zIndex: 200,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+});
+
+const Dialogue = styled("section", {
+  maxWidth: 500,
+  backdropFilter: "blur(20px)",
+  padding: "1em",
+  borderRadius: "3px",
+  borderTop: "1px solid white",
+});
+
+const DialogueHeader = styled("div", {
+  "&> h1": {
+    fontSize: 24,
+  },
+  "&> h2": {
+    fontSize: 18,
+  },
+});
+
+const DialogueBody = styled("div");
+
+const DialogueActions = styled("div", {
+  marginTop: "2em",
+});
+
+const Button = styled("button", {
+  display: "inline-block",
+  padding: "5px 10px",
+  backgroundColor: "white",
+  borderRadius: 3,
+  cursor: "pointer",
+  "& + &": {
+    marginLeft: 10,
+  },
+  "&:hover": {
+    backdropFilter: "brightness(85%)",
+  },
+  variants: {
+    primary: {
+      true: {
+        backgroundColor: "$blue",
+        color: "white",
+      },
+    },
+  },
+});

--- a/src/components/JoinBoard/index.ts
+++ b/src/components/JoinBoard/index.ts
@@ -1,0 +1,1 @@
+export { JoinBoard } from "./JoinBoard";

--- a/src/styles/globalStyles.ts
+++ b/src/styles/globalStyles.ts
@@ -12,6 +12,7 @@ const styles: Record<string, CSS> = {
   "html, body": {
     margin: 0,
     padding: 0,
+    fontFamily: "$text",
   },
 };
 

--- a/src/styles/stitchesConfig.ts
+++ b/src/styles/stitchesConfig.ts
@@ -12,8 +12,11 @@ export const { styled, globalCss } = createStitches({
       border: "rgba(144, 144, 144, .32)",
       active: "dodgerblue",
       red: "#E35549",
+      redHover: "#BF483D",
       blue: "#5556AD",
+      blueHover: "#3E4080",
       green: "#36865A",
+      greenHover: "#296644",
     },
     space: {
       0: "2px",

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,10 +11,13 @@ export interface FSBoard {
   bindings: string[];
 }
 
+export type BoardId = string;
+
 export interface FSAdapter {
   isLoading: boolean;
   createDocument: () => string;
   loadDocument: (input: Uint8Array) => void;
   serialiseDocument: () => Uint8Array;
   eventHandlers: TldrawProps;
+  createDuplicate: (boardId: BoardId) => Promise<BoardId>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,17 @@ export interface FSBoard {
 }
 
 export type BoardId = string;
+export type UserId = string;
+
+export type BoardMeta = {
+  id: BoardId;
+  createdBy: UserId;
+  createdOn: Date;
+};
+
+export type FSUser = {
+  id: UserId;
+};
 
 export interface FSAdapter {
   isLoading: boolean;
@@ -19,5 +30,7 @@ export interface FSAdapter {
   loadDocument: (input: Uint8Array) => void;
   serialiseDocument: () => Uint8Array;
   eventHandlers: TldrawProps;
-  createDuplicate: (boardId: BoardId) => Promise<BoardId>;
+  createDuplicate: (boardId: BoardId) => BoardId;
+  board: BoardMeta;
+  user: FSUser;
 }


### PR DESCRIPTION
- Adds a Fullscreen user identity that is stored in localStorage
- Record board creator in y.js

Todo

- [x] Add dialogue
- [x] Prevent edits and presence broadcast until board is joined
- [x] Only show dialogue on the web
- [x] Don't show dialogue for board creator
- [x] Implement `createDuplicate` in yjs provider