### PR TITLE
Show board not found alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Self-hosted Urbanist web font [#59](https://github.com/interalia-studio/fullscreen/pull/59)
 - More tools for the new toolbar [#61](https://github.com/interalia-studio/fullscreen/pull/61)
 - Onboarding dialogue when joining a board on the web [#66](https://github.com/interalia-studio/fullscreen/pull/66)
+- Add board-not-found dialogue [#69](https://github.com/interalia-studio/fullscreen/pull/69)
 
 ### Changed
 

--- a/src/components/BoardStatusDialogue/BoardStatusDialogue.tsx
+++ b/src/components/BoardStatusDialogue/BoardStatusDialogue.tsx
@@ -1,0 +1,37 @@
+import { useContext, useEffect, useState } from "react";
+
+import { Button } from "../Button";
+import { StoreContext } from "../Store";
+import { BoardStatus } from "~/types";
+import { Dialogue } from "../Dialogue";
+
+export const BoardStatusDialogue = () => {
+  const store = useContext(StoreContext);
+  const [visible, setVisible] = useState(false);
+
+  const shouldDisplay = visible && store.status === BoardStatus.NotFound;
+
+  useEffect(() => {
+    setTimeout(() => setVisible(true), 1000);
+  }, []);
+
+  return (
+    shouldDisplay && (
+      <Dialogue
+        header={<h1>Board not found</h1>}
+        actions={
+          <>
+            <Button primary onClick={() => store.handleNewProject()}>
+              Create a new board
+            </Button>
+            <Button onClick={() => store.handleOpenProject()}>
+              Open an existing board
+            </Button>
+          </>
+        }
+      >
+        Check if your link is correct and still valid.
+      </Dialogue>
+    )
+  );
+};

--- a/src/components/BoardStatusDialogue/index.ts
+++ b/src/components/BoardStatusDialogue/index.ts
@@ -1,0 +1,1 @@
+export { BoardStatusDialogue } from "./BoardStatusDialogue";

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,0 +1,27 @@
+import { styled } from "~/styles";
+
+export const Button = styled("button", {
+  display: "inline-block",
+  padding: "5px 10px",
+  backgroundColor: "white",
+  borderRadius: "$2",
+  borderWidth: "2px",
+  cursor: "pointer",
+  "& + &": {
+    marginLeft: 10,
+  },
+  "&:hover": {
+    backgroundColor: "$hover",
+  },
+  variants: {
+    primary: {
+      true: {
+        backgroundColor: "$blue",
+        color: "white",
+        "&:hover": {
+          backgroundColor: "$blueHover",
+        },
+      },
+    },
+  },
+});

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -1,0 +1,1 @@
+export { Button } from "./Button";

--- a/src/components/Dialogue/Dialogue.tsx
+++ b/src/components/Dialogue/Dialogue.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { styled } from "~/styles";
+
+export const Dialogue: React.FC<{
+  children: React.ReactNode;
+  header: React.ReactNode;
+  actions: React.ReactNode;
+}> = (props) => {
+  return (
+    <ModalWrapper>
+      <InnerDialogue>
+        {props.header && <DialogueHeader>{props.header}</DialogueHeader>}
+        <DialogueBody>{props.children}</DialogueBody>
+        {props.actions && <DialogueActions>{props.actions}</DialogueActions>}
+      </InnerDialogue>
+    </ModalWrapper>
+  );
+};
+
+Dialogue.defaultProps = {
+  header: null,
+  actions: null,
+};
+
+const ModalWrapper = styled("div", {
+  position: "absolute",
+  top: 0,
+  left: 0,
+  width: "100vw",
+  height: "100vh",
+  backgroundColor: "rgba(255, 255, 255, 0.7)",
+  zIndex: 200,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+});
+
+const InnerDialogue = styled("section", {
+  maxWidth: 500,
+  backdropFilter: "blur(20px)",
+  padding: "1em",
+  borderRadius: "3px",
+  borderTop: "1px solid white",
+});
+
+const DialogueHeader = styled("div", {
+  "&> h1": {
+    fontSize: 24,
+  },
+  "&> h2": {
+    fontSize: 18,
+  },
+});
+
+const DialogueBody = styled("div");
+
+const DialogueActions = styled("div", {
+  marginTop: "2em",
+});

--- a/src/components/Dialogue/index.ts
+++ b/src/components/Dialogue/index.ts
@@ -1,0 +1,1 @@
+export { Dialogue } from "./Dialogue";

--- a/src/components/JoinBoard/JoinBoard.tsx
+++ b/src/components/JoinBoard/JoinBoard.tsx
@@ -1,6 +1,8 @@
 import { useContext } from "react";
 import { useNavigate } from "react-router-dom";
-import { styled } from "~/styles";
+
+import { Dialogue } from "../Dialogue";
+import { Button } from "../Button";
 import { StoreContext } from "../Store";
 
 export const JoinBoard = () => {
@@ -14,94 +16,33 @@ export const JoinBoard = () => {
 
   // Show the join dialogue once the session is loaded, if current user is not the board
   // author and has not already given consent to join.
-  const displayJoinDialogue =
+  const showDialogue =
     !store.isLoading &&
     store.meta?.createdBy != null &&
     store.meta.createdBy !== store.user.id &&
     !store.collaborationConsent;
 
   return (
-    displayJoinDialogue && (
-      <ModalWrapper>
-        <Dialogue>
-          <DialogueHeader>
+    showDialogue && (
+      <Dialogue
+        header={
+          <>
             <h1>Fullscreen Sprint 3</h1>
             <h2>Created by Rae on April 24, 2022</h2>
-          </DialogueHeader>
-          <DialogueBody>
-            Do you want to join this collaborative board and sync your changes
-            with anyone who has the link?
-          </DialogueBody>
-          <DialogueActions>
+          </>
+        }
+        actions={
+          <>
             <Button primary onClick={() => store.setCollaborationConsent(true)}>
               Join this board
             </Button>
             <Button onClick={handleMakeACopy}>Make a copy</Button>
-          </DialogueActions>
-        </Dialogue>
-      </ModalWrapper>
+          </>
+        }
+      >
+        Do you want to join this collaborative board and sync your changes with
+        anyone who has the link?
+      </Dialogue>
     )
   );
 };
-
-const ModalWrapper = styled("div", {
-  position: "absolute",
-  top: 0,
-  left: 0,
-  width: "100vw",
-  height: "100vh",
-  backgroundColor: "rgba(255, 255, 255, 0.7)",
-  zIndex: 200,
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-});
-
-const Dialogue = styled("section", {
-  maxWidth: 500,
-  backdropFilter: "blur(20px)",
-  padding: "1em",
-  borderRadius: "3px",
-  borderTop: "1px solid white",
-});
-
-const DialogueHeader = styled("div", {
-  "&> h1": {
-    fontSize: 24,
-  },
-  "&> h2": {
-    fontSize: 18,
-  },
-});
-
-const DialogueBody = styled("div");
-
-const DialogueActions = styled("div", {
-  marginTop: "2em",
-});
-
-const Button = styled("button", {
-  display: "inline-block",
-  padding: "5px 10px",
-  backgroundColor: "white",
-  borderRadius: "$2",
-  borderWidth: "2px",
-  cursor: "pointer",
-  "& + &": {
-    marginLeft: 10,
-  },
-  "&:hover": {
-    backgroundColor: "$hover",
-  },
-  variants: {
-    primary: {
-      true: {
-        backgroundColor: "$blue",
-        color: "white",
-        "&:hover": {
-          backgroundColor: "$blueHover",
-        },
-      },
-    },
-  },
-});

--- a/src/lib/adapters/yjs/hook.ts
+++ b/src/lib/adapters/yjs/hook.ts
@@ -12,6 +12,7 @@ import {
   BoardContents,
   BoardId,
   BoardMeta,
+  BoardStatus,
   FSAdapter,
   FSUser,
   UserId,
@@ -34,9 +35,11 @@ export const useYjsAdapter = (boardId: BoardId): FSAdapter => {
   // Fullscreen-scoped user.
   const [fsUser, _] = useState<FSUser>({ id: getUserId() });
 
-  // Board metadata synced to y.js
-  const [boardMeta, setBoardMeta] = useState<BoardMeta>(null);
+  // Availability of the board in the store.
+  const [boardStatus, setBoardStatus] = useState(BoardStatus.NotFound);
 
+  // Board data synced to y.js
+  const [boardMeta, setBoardMeta] = useState<BoardMeta>();
   const [boardContents, setBoardContents] = useState({} as BoardContents);
 
   // When set, don't broadcast changes and presence.
@@ -75,11 +78,23 @@ export const useYjsAdapter = (boardId: BoardId): FSAdapter => {
    * Update board metadata state from y.js
    */
   const updateBoardMeta = () => {
-    setBoardMeta({
-      id: store.board.get("id"),
+    const id = store.board.get("id");
+
+    // As we can't distinguish a non-existing board from a board with no changes
+    // we use the board id meta attribute as a proxy. If a board is loaded that does
+    // not exist in the WebsocketProvider, the y.js board id will not be available.
+    // Here, the board status is set to ok only if the board id that is expected locally
+    // matches what can be loaded from the store.
+    if (id === boardId) {
+      setBoardStatus(BoardStatus.Ok);
+    }
+
+    setBoardMeta((prev) => ({
+      ...prev,
+      id,
       createdBy: store.board.get("createdBy"),
       createdOn: new Date(store.board.get("createdOn")),
-    });
+    }));
   };
 
   /**
@@ -119,12 +134,13 @@ export const useYjsAdapter = (boardId: BoardId): FSAdapter => {
     async function setup() {
       store.board.observe(updateBoardMeta);
       store.yShapes.observeDeep(updateBoardContentsFromYjs);
-      updateBoardMeta;
+      updateBoardMeta();
       updateBoardContentsFromYjs();
       setLoading(false);
     }
 
     const tearDown = () => {
+      store.board.unobserve(updateBoardMeta);
       store.yShapes.unobserveDeep(updateBoardContentsFromYjs);
       if (networkProvider) networkProvider.disconnect();
     };
@@ -229,11 +245,8 @@ export const useYjsAdapter = (boardId: BoardId): FSAdapter => {
     updatePresence,
 
     contents: boardContents,
-    meta: {
-      id: boardMeta?.id,
-      createdBy: boardMeta?.createdBy,
-      createdOn: boardMeta?.createdOn,
-    },
+    meta: boardMeta,
+    status: boardStatus,
 
     eventHandlers: {
       onChangePage: handleChangePage,

--- a/src/pages/Board.tsx
+++ b/src/pages/Board.tsx
@@ -5,6 +5,7 @@ import { Store } from "~/components/Store/Store";
 import { Canvas } from "~/components/Canvas";
 import { Toolbar } from "~/components/Toolbar";
 import { JoinBoard } from "~/components/JoinBoard";
+import { BoardStatusDialogue } from "~/components/BoardStatusDialogue";
 
 export const Board = () => {
   const { boardId } = useParams();
@@ -18,6 +19,7 @@ export const Board = () => {
         <Canvas>
           <Toolbar />
           <JoinBoard />
+          <BoardStatusDialogue />
         </Canvas>
       </Store>
     </main>

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,11 @@ export interface FSBoard {
 export type BoardId = string;
 export type UserId = string;
 
+export enum BoardStatus {
+  Ok,
+  NotFound,
+}
+
 export type BoardMeta = {
   /**
    * Fullscreen board id (store state).
@@ -80,6 +85,11 @@ export interface FSAdapter {
    * Update presence information of the current user.
    */
   updatePresence: (tdUser: TDUser) => void;
+
+  /**
+   * Availability of the board.
+   */
+  status: BoardStatus;
 
   /**
    * Metadata about the current board as it exists in the network.


### PR DESCRIPTION
This is a bit of a workaround... y.js websocket provider doesn't tell us if a document does not exist. In order to try and tell that anyway we store the board id in the document and then say the board is not found if the board id loaded from y.js does not match what we expected to find.

Of course this also means that all existing boards are now "not found".

Also, I haven't figured out how to tell when y.js has finished syncing from the websocket provider so the "board not found" dialogue is just shown after a 1 second timeout.

## 📋 Checklist

- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
